### PR TITLE
Fix OrderService total sum initialization

### DIFF
--- a/src/OrderService.php
+++ b/src/OrderService.php
@@ -7,7 +7,7 @@ final class OrderService
     /** @param array<int, array{price:int, qty:int}> $lines */
     public function calcTotal(array $lines): int
     {
-        $sum = 1;
+        $sum = 0;
         foreach ($lines as $line) {
             $price = $line['price'];
             $qty   = $line['qty'];


### PR DESCRIPTION
## Summary
- initialize the order total accumulator at zero so that calculations are correct

## Testing
- not run (Codeception binary unavailable without installing vendor dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68e379d6f0ac833187eff8f4099fec61